### PR TITLE
allow configuring max user connections to limit db connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,5 +145,6 @@ and [stunnel](http://linux.die.net/man/8/stunnel) configurations to see what set
 - `PGBOUNCER_STUNNEL_LOGLEVEL` Default is notice (5). Set this var to pass a syslog level name or number value to stunnel.  This corresponds to the stunnel global configuration option called "debug".
 - `ENABLE_STUNNEL_AMAZON_RDS_FIX` Default is unset. Set this var if you are connecting to an Amazon RDS instance of postgres.
  Adds `options = NO_TICKET` which is documented to make stunnel work correctly after a dyno resumes from sleep. Otherwise, the dyno will lose connectivity to RDS.
+- `PGBOUNCER_MAX_USER_CONNECTIONS` Default is 50. Set this var if you need to allow more than this many connections per-user to a database.
 
 For more info, see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -29,6 +29,7 @@ default_pool_size = ${PGBOUNCER_DEFAULT_POOL_SIZE:-5}
 min_pool_size = ${PGBOUNCER_MIN_POOL_SIZE:-0}
 reserve_pool_size = ${PGBOUNCER_RESERVE_POOL_SIZE:-1}
 reserve_pool_timeout = ${PGBOUNCER_RESERVE_POOL_TIMEOUT:-5.0}
+max_user_connections = ${PGBOUNCER_MAX_USER_CONNECTIONS:-50}
 server_lifetime = ${PGBOUNCER_SERVER_LIFETIME:-1800}
 server_idle_timeout = ${PGBOUNCER_SERVER_IDLE_TIMEOUT:-300}
 log_connections = ${PGBOUNCER_LOG_CONNECTIONS:-0}


### PR DESCRIPTION
## Problem

When there is heavy slowness, apps using pgbouncer spike their connections causing the shared db to run out of connections.
## Solution

Allow limiting the total number of connections to the shared db.
