### PR TITLE
Allow configuration of max_db_connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,5 +146,6 @@ and [stunnel](http://linux.die.net/man/8/stunnel) configurations to see what set
 - `ENABLE_STUNNEL_AMAZON_RDS_FIX` Default is unset. Set this var if you are connecting to an Amazon RDS instance of postgres.
  Adds `options = NO_TICKET` which is documented to make stunnel work correctly after a dyno resumes from sleep. Otherwise, the dyno will lose connectivity to RDS.
 - `PGBOUNCER_MAX_USER_CONNECTIONS` Default is 50. Set this var if you need to allow more than this many connections per-user to a database.
+- `PGBOUNCER_MAX_DB_CONNECTIONS` Default is unlimited. Set this var if you need to limit the total available connections per database.
 
 For more info, see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -30,6 +30,7 @@ min_pool_size = ${PGBOUNCER_MIN_POOL_SIZE:-0}
 reserve_pool_size = ${PGBOUNCER_RESERVE_POOL_SIZE:-1}
 reserve_pool_timeout = ${PGBOUNCER_RESERVE_POOL_TIMEOUT:-5.0}
 max_user_connections = ${PGBOUNCER_MAX_USER_CONNECTIONS:-50}
+max_db_connections = ${PGBOUNCER_MAX_DB_CONNECTIONS:--1}
 server_lifetime = ${PGBOUNCER_SERVER_LIFETIME:-1800}
 server_idle_timeout = ${PGBOUNCER_SERVER_IDLE_TIMEOUT:-300}
 log_connections = ${PGBOUNCER_LOG_CONNECTIONS:-0}


### PR DESCRIPTION
Set the default maximum connections for a given database connection to the default value of `unlimited`, with the ability to customize that amount with the PGBOUNCER_MAX_DB_CONNECTIONS environment variable.
