### PR TITLE
Allow configuration of dns_max_ttl

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -40,6 +40,7 @@ stats_period = ${PGBOUNCER_STATS_PERIOD:-120}
 pkt_buf = ${PGBOUNCER_PKT_BUF:-4096}
 sbuf_loopcnt = ${PGBOUNCER_SBUF_LOOPCNT:-20}
 server_tls_sslmode = ${PGBOUNCER_SERVER_TLS_SSLMODE:-prefer}
+dns_max_ttl = ${PGBOUNCER_DNS_TTL:-1}
 [databases]
 EOFEOF
 


### PR DESCRIPTION
# Problem
When our databases failover, our database dns entries change IPs. The
DNS entries have a two second TTL that is not respected by pgbouncer:
https://pgbouncer.github.io/faq.html#how-to-failover

The default value for dns_max_ttl is 15 seconds:
https://pgbouncer.github.io/config.html#dnsmaxttl.

# Solution
We set the default dns_max_ttl to 1 second to pick up dns changes
more quickly.

@stitchfix/eng-platform 